### PR TITLE
Proposed fix for some CPANTESTER fail report.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'perl', '5.014';
 requires 'Moose';
 requires 'JSON::MaybeXS';
 requires 'IPC::Open3';


### PR DESCRIPTION
Hi @pplu 

Please review the PR.
Proposed to fix some of the fail reports as below as the package BLOCK syntax was introduced in 5.014.
https://www.perl.com/pub/2011/05/new-features-of-perl-514-package-block.html/

https://www.cpantesters.org/cpan/report/5967725c-5518-11e8-a1cf-bb670eaac09d

Many Thanks
Best Regards,
Mohammad S Anwar