### PR TITLE
 Set custom config via config attribute

### DIFF
--- a/lib/Kubectl/CLIWrapper.pm
+++ b/lib/Kubectl/CLIWrapper.pm
@@ -6,16 +6,15 @@ package Kubectl::CLIWrapper {
 
   our $VERSION = '0.02';
 
-  has server => (is => 'ro', isa => 'Str');
-  has username => (is => 'ro', isa => 'Str');
-  has password => (is => 'ro', isa => 'Str');
-  has token => (is => 'ro', isa => 'Str');
   has kubeconfig => (is => 'ro', isa => 'Str', predicate => 'has_kubeconfig');
+  has kubectl => (is => 'ro', isa => 'Str', default => 'kubectl');
+  has namespace => (is => 'ro', isa => 'Str', predicate => 'has_namespace');
+  has password => (is => 'ro', isa => 'Str', predicate => 'has_password');
+  has server => (is => 'ro', isa => 'Str', predicate => 'has_server');
+  has token => (is => 'ro', isa => 'Str', predicate => 'has_token');
+  has username => (is => 'ro', isa => 'Str', predicate => 'has_username');
 
   has insecure_tls => (is => 'ro', isa => 'Bool', default => 0);
-  has namespace => (is => 'ro', isa => 'Str', default => 'default');
-
-  has kubectl => (is => 'ro', isa => 'Str', default => 'kubectl');
 
   has kube_options => (
         is      => 'ro',
@@ -27,13 +26,13 @@ package Kubectl::CLIWrapper {
   sub build_options {
     my $self = shift;
     my %options = ();
-    $options{ server } = $self->server if (defined $self->server);
-    $options{ username } = $self->username if (defined $self->username);
-    $options{ password } = $self->password if (defined $self->password);
-    $options{ namespace } = $self->namespace;
-    $options{ 'insecure-skip-tls-verify' } = 'true' if ($self->insecure_tls);
 
+    $options{server}     = $self->server     if $self->has_server;
+    $options{username}   = $self->username   if $self->has_username;
+    $options{password}   = $self->password   if $self->has_password;
+    $options{namespace}  = $self->namespace  if $self->has_namespace;
     $options{kubeconfig} = $self->kubeconfig if $self->has_kubeconfig;
+    $options{'insecure-skip-tls-verify'} = 'true' if $self->insecure_tls;
 
     return [ map { "--$_=$options{ $_ }" } keys %options ];
   }
@@ -175,7 +174,7 @@ A Boolean flag that tells kubectl to not verify the certificate of the server it
 
 =head2 namespace
 
-The Kubernetes namespace to operate in. Defaults to C<default>.
+The Kubernetes namespace to operate in.
 
 =head1 METHODS
 

--- a/t/02_interface.t
+++ b/t/02_interface.t
@@ -9,7 +9,7 @@ use Kubectl::CLIWrapper;
 {
   my $control = Kubectl::CLIWrapper->new(namespace => 'ns1');
   my $command = join ' ', $control->command_for('create', 'pod');
-  diag $command;
+  note $command;
   cmp_ok($command, 'eq', 'kubectl --namespace=ns1 create pod');
 }
 
@@ -22,7 +22,7 @@ use Kubectl::CLIWrapper;
     kubeconfig => './foo',
   );
   my $command = join ' ', $control->command_for('create', 'pod');
-  diag $command;
+  note $command;
   like($command, qr/--username=u1/);
   like($command, qr/--password=p1/);
   like($command, qr|--server=https://server1.example.com|);

--- a/t/02_interface.t
+++ b/t/02_interface.t
@@ -15,27 +15,19 @@ use Kubectl::CLIWrapper;
 
 {
   my $control = Kubectl::CLIWrapper->new(
-    namespace => 'ns1',
-    server => 'https://server1.example.com',
-    username => 'u1',
-    password => 'p1',
+    namespace  => 'ns1',
+    server     => 'https://server1.example.com',
+    username   => 'u1',
+    password   => 'p1',
+    kubeconfig => './foo',
   );
   my $command = join ' ', $control->command_for('create', 'pod');
   diag $command;
   like($command, qr/--username=u1/);
   like($command, qr/--password=p1/);
   like($command, qr|--server=https://server1.example.com|);
-}
-
-{
-  my $control = Kubectl::CLIWrapper->new(
-    server => 'https://server1.example.com',
-    username => 'u1',
-    password => 'p1',
-  );
-  my $command = join ' ', $control->command_for('create', 'pod');
-  diag $command;
-  like($command, qr/--namespace=default/);
+  like($command, qr/--namespace=ns1/);
+  like($command, qr|--kubeconfig=\./foo\b|);
 }
 
 {


### PR DESCRIPTION
Bon dia Jose,

I have a patch that enables us (me and my employer) to use different kubectl configs. We have several clouds and therefore use `kubectl --kubeconfig=/path/to/kubeconfig`. The first commit deals with that.

I've also taken the liberty to add some predicates, so `$foo if defined $self->foo` becomes `$foo if $self->has_foo`.

And I've changed `diag` to `note` in the testsuite, diag always shows diagnostics, note only when running `prove -v`.

Thanks for the module, I like it!

Mucho gracias :) 
Wesley