### PR TITLE
Fix auth token being ignored

### DIFF
--- a/lib/Kubectl/CLIWrapper.pm
+++ b/lib/Kubectl/CLIWrapper.pm
@@ -30,6 +30,7 @@ package Kubectl::CLIWrapper {
     $options{server}     = $self->server     if $self->has_server;
     $options{username}   = $self->username   if $self->has_username;
     $options{password}   = $self->password   if $self->has_password;
+    $options{token}      = $self->token      if $self->has_token;
     $options{namespace}  = $self->namespace  if $self->has_namespace;
     $options{kubeconfig} = $self->kubeconfig if $self->has_kubeconfig;
     $options{'insecure-skip-tls-verify'} = 'true' if $self->insecure_tls;

--- a/t/02_interface.t
+++ b/t/02_interface.t
@@ -31,6 +31,19 @@ use Kubectl::CLIWrapper;
 }
 
 {
+  my $control = Kubectl::CLIWrapper->new(
+    namespace    => 'ns1',
+    server       => 'https://server1.example.com',
+    token        => 't1',
+  );
+  my $command = join ' ', $control->command_for('create', 'pod');
+  note $command;
+  like($command, qr/--namespace=ns1/);
+  like($command, qr|--server=https://server1.example.com|);
+  like($command, qr/--token=t1/);
+}
+
+{
   my $ok = Kubectl::CLIWrapper->new(
     kubectl => 't/fake_kubectl/ok',
     namespace => 'x',


### PR DESCRIPTION
Token specified on Kubectl::CLIWrapper object instantiation is ignored and does not get to kubectl.