### PR TITLE
Allow passing a sub to 'token' attribute during construction

### DIFF
--- a/lib/Kubectl/CLIWrapper.pm
+++ b/lib/Kubectl/CLIWrapper.pm
@@ -11,29 +11,27 @@ package Kubectl::CLIWrapper {
   has namespace => (is => 'ro', isa => 'Str', predicate => 'has_namespace');
   has password => (is => 'ro', isa => 'Str', predicate => 'has_password');
   has server => (is => 'ro', isa => 'Str', predicate => 'has_server');
-  has token => (is => 'ro', isa => 'Str', predicate => 'has_token');
+  has token => (is => 'ro', isa => 'Str|CodeRef', predicate => 'has_token');
   has username => (is => 'ro', isa => 'Str', predicate => 'has_username');
 
   has insecure_tls => (is => 'ro', isa => 'Bool', default => 0);
 
-  has kube_options => (
-        is      => 'ro',
-        isa     => 'ArrayRef[Str]',
-        lazy    => 1,
-        builder => 'build_options',
-  );
-
-  sub build_options {
+  sub kube_options {
     my $self = shift;
     my %options = ();
 
     $options{server}     = $self->server     if $self->has_server;
     $options{username}   = $self->username   if $self->has_username;
     $options{password}   = $self->password   if $self->has_password;
-    $options{token}      = $self->token      if $self->has_token;
     $options{namespace}  = $self->namespace  if $self->has_namespace;
     $options{kubeconfig} = $self->kubeconfig if $self->has_kubeconfig;
     $options{'insecure-skip-tls-verify'} = 'true' if $self->insecure_tls;
+
+    if ($self->has_token) {
+      $options{token} = ref($self->token) eq 'CODE'
+        ? &{$self->token}()
+        : $self->token;
+    }
 
     return [ map { "--$_=$options{ $_ }" } keys %options ];
   }

--- a/t/02_interface.t
+++ b/t/02_interface.t
@@ -44,6 +44,26 @@ use Kubectl::CLIWrapper;
 }
 
 {
+  my $token_num = 1;
+  my $control = Kubectl::CLIWrapper->new(
+    namespace    => 'ns1',
+    server       => 'https://server1.example.com',
+    token        => sub { sprintf("t%s", $token_num++) }
+  );
+  my $command1 = join ' ', $control->command_for('create', 'pod');
+  note $command1;
+  like($command1, qr/--namespace=ns1/);
+  like($command1, qr|--server=https://server1.example.com|);
+  like($command1, qr/--token=t1/);
+
+  my $command2 = join ' ', $control->command_for('create', 'pod');
+  note $command2;
+  like($command2, qr/--namespace=ns1/);
+  like($command2, qr|--server=https://server1.example.com|);
+  like($command2, qr/--token=t2/);
+}
+
+{
   my $ok = Kubectl::CLIWrapper->new(
     kubectl => 't/fake_kubectl/ok',
     namespace => 'x',


### PR DESCRIPTION
Up until now, the only way to authenticate against a kubernetes cluster
via a token was specifying the token (a string) on Kubectl::CLIWrapper
instantiation.

With this changeset, 'token' attribute can either be:
a) A string
b) A reference to a sub
When a sub is specified, it will be called by Kubectl::CLIWrapper before
each call to kubectl cli.

**The intent behind this changeset is enabling token auto-refresh.**